### PR TITLE
Replace the ComparisionOperatorUsageSniff with the DisallowEqualOperatorSniff

### DIFF
--- a/src/Ubitransport/Sniffs/Operators/DisallowEqualOperatorsSniff.php
+++ b/src/Ubitransport/Sniffs/Operators/DisallowEqualOperatorsSniff.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ubitransport\PhpCodeSniffs\Ubitransport\Sniffs\Operators;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class DisallowEqualOperatorsSniff implements Sniff
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function register()
+    {
+        return [
+            T_IS_EQUAL,
+            T_IS_NOT_EQUAL
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $operatorReplacement = '';
+        $errorMessage = 'Operator %s prohibited; use %s instead';
+        if ($tokens[$stackPtr]['code'] === T_IS_EQUAL) {
+            $operatorReplacement = '===';
+            $fixable = $phpcsFile->addFixableError(
+                sprintf($errorMessage, '==', $operatorReplacement),
+                $stackPtr,
+                'Prohibited'
+            );
+        } else {
+            $operatorReplacement = '!==';
+            $fixable = $phpcsFile->addFixableError(
+                sprintf($errorMessage, '!=', $operatorReplacement),
+                $stackPtr,
+                'Prohibited'
+            );
+        }
+
+        if ($fixable) {
+            $phpcsFile->fixer->beginChangeset();
+            $phpcsFile->fixer->replaceToken($stackPtr, $operatorReplacement);
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/src/Ubitransport/ruleset.xml
+++ b/src/Ubitransport/ruleset.xml
@@ -71,7 +71,7 @@
         <exclude name="Squiz.ControlStructures.InlineIfDeclaration.NoBrackets"/>
         <exclude name="Squiz.Files.FileExtension"/>
         <exclude name="Squiz.Formatting.OperatorBracket.MissingBrackets"/>
-        <exclude name="Squiz.Operators.ComparisonOperatorUsage.ImplicitTrue"/>
+        <exclude name="Squiz.Operators.ComparisonOperatorUsage"/>
         <exclude name="Squiz.Objects.ObjectInstantiation"/>
         <exclude name="Squiz.PHP.DisallowBooleanStatement.Found"/>
         <exclude name="Squiz.PHP.DisallowComparisonAssignment.AssignedComparison"/>


### PR DESCRIPTION
Base on this [discusion](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/493#issuecomment-2113234959), the ComparisionOperatorUsageSniff will never replace the `==` by `===`.

As we don't use the other check of this sniffer (ImplicitTrue), i create a sniffer to auto fix the is identical and is not identical check. 

This allow PHPStorm to correct those cases directly in the reformate code action. 
